### PR TITLE
Add gallery `Order` to prioritize driveline, buildings, braking demos

### DIFF
--- a/DrivelineSciML/docs/index.md
+++ b/DrivelineSciML/docs/index.md
@@ -3,6 +3,7 @@ Title = "Driveline SciML — nonlinear isolator calibration"
 Description = "Two-stage parameter calibration of a nonlinear torsional isolator in an EV driveline."
 Tags = ["sciml", "parameter-calibration", "nonlinear-dynamics"]
 Cover = "assets/icon.svg"
+Order = 1
 ```
 
 # Driveline SciML Demo

--- a/DynamicSteadyState/docs/index.md
+++ b/DynamicSteadyState/docs/index.md
@@ -3,6 +3,7 @@ Title = "Dynamic Steady State — three-zone building"
 Description = "One building model reused for steady-state HVAC sizing and 24-hour transient operation."
 Tags = ["thermal", "buildings", "steady-state"]
 Cover = "assets/icon_three_zone_building.svg"
+Order = 3
 ```
 
 # Dynamic Steady State Demo

--- a/FrictionBrakeDemo/docs/index.md
+++ b/FrictionBrakeDemo/docs/index.md
@@ -3,6 +3,7 @@ Title = "Friction Brake — thermal braking dynamics"
 Description = "Vehicle friction brake converting braking energy to disk and pad heat over a drive cycle."
 Tags = ["thermal", "automotive", "components"]
 Cover = "assets/icon.svg"
+Order = 4
 ```
 
 # Friction Brake Demo

--- a/ThermalHouseDemo/docs/index.md
+++ b/ThermalHouseDemo/docs/index.md
@@ -3,6 +3,7 @@ Title = "Thermal House — building heating dynamics"
 Description = "Heat transfer through a building envelope with HVAC and weather-driven control."
 Tags = ["thermal", "components", "buildings"]
 Cover = "assets/icon.svg"
+Order = 2
 ```
 
 # Thermal House Demo


### PR DESCRIPTION
Sets the display order of the DyadDocs example gallery using the new optional
`Order` field in each demo's `@cardmeta` block. Lower numbers sort earlier;
demos without an `Order` follow, alphabetical within each group.

| Order | Demo | Requested as |
|---|---|---|
| 1 | `DrivelineSciML` | driveline |
| 2 | `ThermalHouseDemo` | buildings |
| 3 | `DynamicSteadyState` | buildings (three-zone) |
| 4 | `FrictionBrakeDemo` | braking system |

The requested order also included **datacenter, quadrotor, helicopter, and
jet (F-16)** — those demos don't exist in this repo yet, so their positions
are intentionally left open (the `Order` field accepts reals, so they can be
slotted in between existing demos later without renumbering).

Unranked demos (CoffeeMug, QuarterTruck, Turkey) fall to the back of the
gallery, alphabetically.

### How ordering works
The `Order` field is consumed by the DyadDocs `DyadDemoIngestion` stage, which
sorts demos by `(Order, name)` and emits an ordered `@overviewgallery`. See the
companion DyadDocs PR (branch `as/gallery-improvements`). No change here has any
effect until that lands; this PR is inert on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)